### PR TITLE
:bug: Adding empty dir, to avoid failures

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -14,6 +14,9 @@ jobs:
       SITE_DIR: "gh-pages"
       PR_PATH: pull-${{ github.event.number }}
     steps:
+      - name: Make empty dir
+        run: "mkdir -p ${{ env.PR_PATH }}"
+
       - name: Removing PR preview
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
See: https://github.com/cardil/solution-pattern-event-mesh-for-microservices/pull/2#discussion_r1890671059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the PR close workflow to create an empty directory before removing the PR preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->