### PR TITLE
:bug: Use different GH action to properly clean up preview branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build_site:
     name: "Build site with Antora"
-    runs-on: [ubuntu-24.04]
+    runs-on: [ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
       repository-projects: write
       id-token: write
-    runs-on: [ubuntu-24.04]
+    runs-on: [ubuntu-22.04]
     needs: [build_site]
     name: "Deploy GitHub Pages"
     if: github.event_name != 'pull_request'
@@ -48,12 +48,13 @@ jobs:
           name: site
           path: "${{ github.workspace }}/${{ env.SITE_DIR }}"
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          folder: "${{ env.SITE_DIR }}"
-          commit-message: "[CI] Publish Documentation for ${{ github.sha }}"
-          clean: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "${{ env.SITE_DIR }}"
+          commit_message: "[CI] Publish Documentation for ${{ github.sha }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
   
   # Based on : https://daiyi.co/blog/pr-previews-for-github-pages/
   deploy_preview:
@@ -64,7 +65,7 @@ jobs:
       id-token: write
     env:
       PR_PATH: pull-${{ github.event.number }}
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: [ ubuntu-22.04 ]
     needs: [ build_site ]
     name: "Deploy preview for PR"
     if: github.event_name == 'pull_request'
@@ -90,13 +91,14 @@ jobs:
           path: "${{ github.workspace }}/${{ env.SITE_DIR }}"
 
       - name: Deploy PR preview
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          folder: "${{ env.SITE_DIR }}"
-          target-folder: "${{ env.PR_PATH }}"
-          commit-message: "[CI] Publish Preview for PR #${{ github.event.number }}"
-          clean: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "${{ env.SITE_DIR }}"
+          destination_dir: "${{ env.PR_PATH }}"
+          commit_message: "[CI] Publish Preview for PR #${{ github.event.number }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
       - name: Update comment
         uses: hasura/comment-progress@v2.3.0

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -20,13 +20,14 @@ jobs:
         run: "mkdir -p ${{ env.SITE_DIR }}"
 
       - name: Removing PR preview
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          folder: "${{ env.SITE_DIR }}"
-          target-folder: "${{ env.PR_PATH }}"
-          commit-message: "[CI] Delete Preview for PR #${{ github.event.number }}"
-          clean: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "${{ env.SITE_DIR }}"
+          destination_dir: "${{ env.PR_PATH }}"
+          commit_message: "[CI] Delete Preview for PR #${{ github.event.number }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
       - name: Comment on PR
         uses: hasura/comment-progress@v2.3.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows for improved deployment processes.
	- Changed the action used for deployment and preview deletion to a new version with updated parameters.
	- Adjusted the runner environment from Ubuntu 24.04 to Ubuntu 22.04 for all jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->