### PR TITLE
:bug: Keep preview files, when updating the main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: "${{ env.SITE_DIR }}"
+          keep_files: true
           commit_message: "[CI] Publish Documentation for ${{ github.sha }}"
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -9,7 +9,7 @@ jobs:
       contents: write
       pull-requests: write
     name: Delete preview for PR
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: [ ubuntu-22.04 ]
     env:
       SITE_DIR: "gh-pages"
       PR_PATH: pull-${{ github.event.number }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced documentation deployment process by adding a `keep_files: true` parameter to retain existing files on GitHub Pages.
	- Updated the operating system environment for closing pull requests from Ubuntu 24.04 to Ubuntu 22.04.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->